### PR TITLE
Auth/enforce auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "shimmiestack",
-    "version": "1.3.12",
+    "version": "1.3.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "shimmiestack",
-            "version": "1.3.12",
+            "version": "1.3.16",
             "license": "MIT",
             "dependencies": {
                 "@types/supertest": "^2.0.11",
@@ -32,7 +32,7 @@
                 "typescript": "^4.4.4"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1215,9 +1215,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "engines": {
                 "node": ">=8"
             }
@@ -3867,14 +3867,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/pretty-format/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/pretty-format/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -4308,14 +4300,6 @@
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
             },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "engines": {
                 "node": ">=8"
             }
@@ -5911,9 +5895,9 @@
             }
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "ansi-styles": {
             "version": "4.3.0",
@@ -7907,11 +7891,6 @@
                 "react-is": "^17.0.1"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-                },
                 "ansi-styles": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -8241,11 +8220,6 @@
                 "strip-ansi": "^6.0.1"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-                },
                 "strip-ansi": {
                     "version": "6.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "publish": "cp README.md  dist && cp package-publish.json dist/package.json && npm run build && npm publish dist "
     },
     "engines": {
-        "node": ">=14"
+        "node": ">=16"
     },
     "repository": {
         "type": "git",

--- a/src/authorizers.ts
+++ b/src/authorizers.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from 'express'
+
+/**
+ * This ia a wrapper function, if enforcing authorization in the shimmie stack it looks for a middleware
+ * function called authorizeApi. This can be used with any middleware to make an endpoint authorized.
+ * This is only there to remind developers to implement auth for each endpoint, it does not do auth for you.
+ * @param authFunc the function that actually does the authorization
+ */
+export const authorizeApi = (authFunc: (req:any, res: any, next: NextFunction) => void) => {
+    // rename the function to __authorizer so when we check if the function s authorized we have a unique name
+    Object.defineProperty(authFunc, "name", { value: "__authorizer" });
+    return authFunc
+}
+
+/**
+ * If no authorization is required on this endpoint use this function.
+ */
+export const noAuthorization = (req:any, res: any, next: NextFunction): void => {
+    next()
+}
+
+/**
+ * If no authorization needs to occur at the middleware use this function.
+ * This is only here for clearer readability when you're using it. It does the same thing as authorize all
+ */
+export const customAuthorization = noAuthorization

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export interface ShimmieConfig {
     mode?: string
     ServerPort: number
     CORS?: CorsOptions
+    enforceAuthorization: boolean
 }
 
 // testing a new naming scheme. Replace IEvent if we like this one better. Easier
@@ -121,7 +122,8 @@ export default function ShimmieStack(
         app,
         'Administration API',
         '/admin',
-        AdminProcessor(eventBase)
+        AdminProcessor(eventBase),
+        config.enforceAuthorization
     )
 
     let modelStore: { [key: string]: any } = {}
@@ -155,7 +157,7 @@ export default function ShimmieStack(
         },
 
         mountProcessor: (name: string, mountPoint: string, router: Router) => {
-            routes.mountApi(app, name, mountPoint, router)
+            routes.mountApi(app, name, mountPoint, router, config.enforceAuthorization)
             return funcs
         },
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -57,7 +57,7 @@ export const mountApi: ApiMounter = (
             // check the handler and middleware for a function called "authorizeApi"
             // express doesnt expose the Layer type :(
             const authorizer: any[] = api.route.stack.filter((layer: any) => {
-                return layer.name === "authorizeApi"
+                return layer.name === "__authorizer"
             })
 
             if(authorizer.length === 0){

--- a/src/shimmieteststack.ts
+++ b/src/shimmieteststack.ts
@@ -70,6 +70,7 @@ export default function ShimmieTestStack(
     const testStack = ShimmieStack(
         {
             ServerPort: 9999 /* ignored because the express server is never started */,
+            enforceAuthorization: false
         },
         memoryBase
     )

--- a/src/tests/routes.test.ts
+++ b/src/tests/routes.test.ts
@@ -1,76 +1,114 @@
-import { Application, Router } from 'express'
+import express, { Application, Router } from 'express'
+import { NextFunction } from 'express-serve-static-core'
 import { mountApi, setApiVersion } from '../routes'
 
 describe('when mounting a processor', () => {
-    it('and its unique it should be fine', async () => {
-        const appMock = jest.fn() as unknown as Application
-        appMock.use = jest.fn()
-        const routerMock = jest.fn() as unknown as Router
-        mountApi(appMock, 'blah', '/blah', routerMock, false)
-        expect(appMock.use).toBeCalledTimes(1)
+    describe('When auth is not enforced', () => {
+
+        it('and its unique it should be fine', async () => {
+            const appMock = jest.fn() as unknown as Application
+            appMock.use = jest.fn()
+            const routerMock = jest.fn() as unknown as Router
+            mountApi(appMock, 'blah', '/blah', routerMock, false)
+            expect(appMock.use).toBeCalledTimes(1)
+        })
+
+        // it('and its a duplicate it should throw', async () => {
+        //     const appMock = jest.fn() as unknown as Application
+        //     appMock.use = jest.fn()
+        //     const routerMock = jest.fn() as unknown as Router
+        //     mountApi(appMock, 'blah', '/boo', routerMock)
+        //     expect(() => mountApi(appMock, 'blah', '/boo', routerMock)).toThrow(
+        //         'Mount point duplicate: /boo'
+        //     )
+        // })
+
+        // Issue: The internal /admin hasn't been mounted yet
+        // it('and its call /admin it should thro', async () => {
+        //     const appMock = jest.fn() as unknown as Application;
+        //     appMock.use = jest.fn();
+        //     const routerMock = jest.fn() as unknown as Router;
+        //     expect(() => mountApi(appMock, 'blah', '/admin', routerMock)).toThrow(
+        //         '"/admin" mount point is reserved'
+        //     );
+        // });
+
+        it('and its missing a slash it should add one', async () => {
+            const appMock = jest.fn() as unknown as Application
+            appMock.use = jest.fn()
+            const routerMock = jest.fn() as unknown as Router
+            mountApi(appMock, 'blah', 'noslash', routerMock, false)
+            expect(appMock.use).toBeCalledWith('/noslash', expect.anything())
+        })
+
+        it('and it has a version it should be pre-pended with a slash', async () => {
+            const appMock = jest.fn() as unknown as Application
+            appMock.use = jest.fn()
+            const routerMock = jest.fn() as unknown as Router
+            setApiVersion('v1')
+            mountApi(appMock, 'blah', 'noslash', routerMock, false)
+            expect(appMock.use).toBeCalledWith('/v1/noslash', expect.anything())
+        })
+
+        it('and it has a slashed version it should be pre-pended with the slash', async () => {
+            const appMock = jest.fn() as unknown as Application
+            appMock.use = jest.fn()
+            const routerMock = jest.fn() as unknown as Router
+            setApiVersion('/v2')
+            mountApi(appMock, 'blah', '/foo', routerMock, false)
+            expect(appMock.use).toBeCalledWith('/v2/foo', expect.anything())
+        })
+
+        it('should be able to change the api version twice', async () => {
+            const appMock = jest.fn() as unknown as Application
+            appMock.use = jest.fn()
+            const routerMock = jest.fn() as unknown as Router
+
+            setApiVersion('/v2 ')
+            mountApi(appMock, 'blah', '/foo ', routerMock, false)
+            expect(appMock.use).toBeCalledWith('/v2/foo', expect.anything())
+
+            setApiVersion(' v4')
+            mountApi(appMock, 'blah', 'bar', routerMock, false)
+            expect(appMock.use).toBeCalledWith('/v4/bar', expect.anything())
+
+            setApiVersion('')
+            mountApi(appMock, 'blah', '  /baz ', routerMock, false)
+            expect(appMock.use).toBeCalledWith('/baz', expect.anything())
+        })
     })
 
-    // it('and its a duplicate it should throw', async () => {
-    //     const appMock = jest.fn() as unknown as Application
-    //     appMock.use = jest.fn()
-    //     const routerMock = jest.fn() as unknown as Router
-    //     mountApi(appMock, 'blah', '/boo', routerMock)
-    //     expect(() => mountApi(appMock, 'blah', '/boo', routerMock)).toThrow(
-    //         'Mount point duplicate: /boo'
-    //     )
-    // })
+    describe('When auth is enforced', () => {
+        it('should fail to mount the router if authorizeApi is provided', async () => {
+            const appMock = jest.fn() as unknown as Application
+            appMock.use = jest.fn()
+            const router = express.Router()
 
-    // Issue: The internal /admin hasn't been mounted yet
-    // it('and its call /admin it should thro', async () => {
-    //     const appMock = jest.fn() as unknown as Application;
-    //     appMock.use = jest.fn();
-    //     const routerMock = jest.fn() as unknown as Router;
-    //     expect(() => mountApi(appMock, 'blah', '/admin', routerMock)).toThrow(
-    //         '"/admin" mount point is reserved'
-    //     );
-    // });
+            router.get('myfakepath', () => {return null})
 
-    it('and its missing a slash it should add one', async () => {
-        const appMock = jest.fn() as unknown as Application
-        appMock.use = jest.fn()
-        const routerMock = jest.fn() as unknown as Router
-        mountApi(appMock, 'blah', 'noslash', routerMock, false)
-        expect(appMock.use).toBeCalledWith('/noslash', expect.anything())
-    })
+            try {
+                mountApi(appMock, 'blah', '/blah', router, true)
+            } catch (e: any) {
+                expect(e.message).toEqual('Authorization Not Implemented for blah at /blah')
+                return
+            }
 
-    it('and it has a version it should be pre-pended with a slash', async () => {
-        const appMock = jest.fn() as unknown as Application
-        appMock.use = jest.fn()
-        const routerMock = jest.fn() as unknown as Router
-        setApiVersion('v1')
-        mountApi(appMock, 'blah', 'noslash', routerMock, false)
-        expect(appMock.use).toBeCalledWith('/v1/noslash', expect.anything())
-    })
+            throw new Error('Mount API should throw')
+        })
 
-    it('and it has a slashed version it should be pre-pended with the slash', async () => {
-        const appMock = jest.fn() as unknown as Application
-        appMock.use = jest.fn()
-        const routerMock = jest.fn() as unknown as Router
-        setApiVersion('/v2')
-        mountApi(appMock, 'blah', '/foo', routerMock, false)
-        expect(appMock.use).toBeCalledWith('/v2/foo', expect.anything())
-    })
+        it('should successfully mount the router if authorizeApi is provided', async () => {
+            const appMock = jest.fn() as unknown as Application
+            appMock.use = jest.fn()
+            const router = express.Router()
 
-    it('should be able to change the api version twice', async () => {
-        const appMock = jest.fn() as unknown as Application
-        appMock.use = jest.fn()
-        const routerMock = jest.fn() as unknown as Router
+            const authorizeApi = (req: any, res: any, next: NextFunction) => {next()}
 
-        setApiVersion('/v2 ')
-        mountApi(appMock, 'blah', '/foo ', routerMock, false)
-        expect(appMock.use).toBeCalledWith('/v2/foo', expect.anything())
+            router.get('myfakepath',
+                authorizeApi,
+                (req, res) => {return null}
+            )
 
-        setApiVersion(' v4')
-        mountApi(appMock, 'blah', 'bar', routerMock, false)
-        expect(appMock.use).toBeCalledWith('/v4/bar', expect.anything())
-
-        setApiVersion('')
-        mountApi(appMock, 'blah', '  /baz ', routerMock, false)
-        expect(appMock.use).toBeCalledWith('/baz', expect.anything())
+            mountApi(appMock, 'blah', '/blah', router, true)
+        })
     })
 })

--- a/src/tests/routes.test.ts
+++ b/src/tests/routes.test.ts
@@ -1,6 +1,7 @@
 import express, { Application, Router } from 'express'
 import { NextFunction } from 'express-serve-static-core'
 import { mountApi, setApiVersion } from '../routes'
+import { noAuthorization, authorizeApi, customAuthorization } from '../authorizers'
 
 describe('when mounting a processor', () => {
     describe('When auth is not enforced', () => {
@@ -84,7 +85,9 @@ describe('when mounting a processor', () => {
             appMock.use = jest.fn()
             const router = express.Router()
 
-            router.get('myfakepath', () => {return null})
+            router.get('myfakepath', () => {
+                return null
+            })
 
             try {
                 mountApi(appMock, 'blah', '/blah', router, true)
@@ -101,11 +104,20 @@ describe('when mounting a processor', () => {
             appMock.use = jest.fn()
             const router = express.Router()
 
-            const authorizeApi = (req: any, res: any, next: NextFunction) => {next()}
 
-            router.get('myfakepath',
-                authorizeApi,
-                (req, res) => {return null}
+            router.get('myfakeauthorizedpath',
+                authorizeApi(noAuthorization),
+                (req, res) => {
+                    return null
+                },
+            )
+
+            router.get('myfakeauthorizedpath',
+                authorizeApi(customAuthorization),
+                (req, res) => {
+                    // some custom auth happens in the handler body
+                    return null
+                },
             )
 
             mountApi(appMock, 'blah', '/blah', router, true)

--- a/src/tests/routes.test.ts
+++ b/src/tests/routes.test.ts
@@ -112,7 +112,7 @@ describe('when mounting a processor', () => {
                 },
             )
 
-            router.get('myfakeauthorizedpath',
+            router.get('myfakeauthorizedpath2',
                 authorizeApi(customAuthorization),
                 (req, res) => {
                     // some custom auth happens in the handler body

--- a/src/tests/routes.test.ts
+++ b/src/tests/routes.test.ts
@@ -6,7 +6,7 @@ describe('when mounting a processor', () => {
         const appMock = jest.fn() as unknown as Application
         appMock.use = jest.fn()
         const routerMock = jest.fn() as unknown as Router
-        mountApi(appMock, 'blah', '/blah', routerMock)
+        mountApi(appMock, 'blah', '/blah', routerMock, false)
         expect(appMock.use).toBeCalledTimes(1)
     })
 
@@ -34,7 +34,7 @@ describe('when mounting a processor', () => {
         const appMock = jest.fn() as unknown as Application
         appMock.use = jest.fn()
         const routerMock = jest.fn() as unknown as Router
-        mountApi(appMock, 'blah', 'noslash', routerMock)
+        mountApi(appMock, 'blah', 'noslash', routerMock, false)
         expect(appMock.use).toBeCalledWith('/noslash', expect.anything())
     })
 
@@ -43,7 +43,7 @@ describe('when mounting a processor', () => {
         appMock.use = jest.fn()
         const routerMock = jest.fn() as unknown as Router
         setApiVersion('v1')
-        mountApi(appMock, 'blah', 'noslash', routerMock)
+        mountApi(appMock, 'blah', 'noslash', routerMock, false)
         expect(appMock.use).toBeCalledWith('/v1/noslash', expect.anything())
     })
 
@@ -52,7 +52,7 @@ describe('when mounting a processor', () => {
         appMock.use = jest.fn()
         const routerMock = jest.fn() as unknown as Router
         setApiVersion('/v2')
-        mountApi(appMock, 'blah', '/foo', routerMock)
+        mountApi(appMock, 'blah', '/foo', routerMock, false)
         expect(appMock.use).toBeCalledWith('/v2/foo', expect.anything())
     })
 })


### PR DESCRIPTION
Add a consistent and conservative authorization model. When enabled, the shimmie stack will throw an error if no auth is provided when mounting an API.

As shown below, when mounting a new endpoint a function called `AuthorizeApi()` must be called, and provided a middleware function. 

Two basic pass through auth options `customAuthorization` and `noAuthorization` are provided in this library. They behave the same, and are only separate for more obvious readability for users. IE am i expecting to see custom auth in the api body or am I expecting no authorization at all. 

```
router.get('myfakeauthorizedpath2',
                authorizeApi((req, res, next) => {some auth happens here}),
                (req, res) => {
                  
                    return  {}
                },
            )
```